### PR TITLE
using utf8 to fix UnicodeDecodeError

### DIFF
--- a/joiner.py
+++ b/joiner.py
@@ -12,7 +12,7 @@ def main(args):
 
     if '3ds' in args.type:
         for cheat in os.listdir('./3ds'):
-            with open(os.path.join('./3ds', cheat), 'r') as file:
+            with open(os.path.join('./3ds', cheat), 'r', encoding="UTF-8") as file:
                 titleid = cheat[:cheat.rfind('.')]
                 lines = [line.strip() for line in file]
                 lines = list(filter(None, lines))


### PR DESCRIPTION
When I try to run this command(py -3 joiner.py 3ds) it gets this error :

Traceback (most recent call last):
  File "joiner.py", line 63, in <module>
    main(parser.parse_args())
  File "joiner.py", line 17, in main
    lines = [line.strip() for line in file]
  File "joiner.py", line 17, in <listcomp>
    lines = [line.strip() for line in file]
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 978: illegal