### PR TITLE
Apply fix from pull request #198 to Switch script

### DIFF
--- a/joiner.py
+++ b/joiner.py
@@ -39,7 +39,7 @@ def main(args):
             for file in files:
                 buildid = file[:file.find('.')]
                 db[titleid][buildid] = {}
-                with open(os.path.join(root, file), 'r') as f:
+                with open(os.path.join(root, file), 'r', encoding="UTF-8") as f:
                     lines = [line.strip() for line in f]
                     lines = list(filter(None, lines))
                     selectedCheat = lines[0]


### PR DESCRIPTION
The commit for using UTF-8 was only applied to the 3DS part of the script. Trying to run the script for Switch cheats still results in errors.