### PR TITLE
Update database updating instruction to actually use releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ If cheat names are truncated, this is due to Luma's limitations, not Sharkive. F
 ## <a name="compile-db"></a>Updating Checkpoint's Cheat Database
 
 To update Checkpoint's cheat database, follow these steps:
+1. Download latest database for your console:
+  - [3DS](https://github.com/FlagBrew/Sharkive/releases/latest/download/3ds.json)
+  - [Switch](https://github.com/FlagBrew/Sharkive/releases/latest/download/switch.json)
+2. Rename `<console>.json` to `cheats.json` and place it in the `/<console>/Checkpoint` folder on your SD card.
+
+<sub>**Note**: `<console>` refers to your device type, either `3ds` or `switch`.</sub>
+
+If you need to build yourself, follow these steps:
 1. Ensure you have [Python 3](https://www.python.org/downloads/) installed.
 2. Clone or download the repository.
 3. Open a command prompt/terminal in your repository folder.


### PR DESCRIPTION
Update Checkpoint cheat database instruction to actually use prebuilt file from release.

Normal user will just get confused for using python and the automatic releases get unused for some reason, they won't check there if they can't use python